### PR TITLE
Add `cache-version` for TruffleRuby builds

### DIFF
--- a/.github/workflows/truffle_ruby.yml
+++ b/.github/workflows/truffle_ruby.yml
@@ -20,6 +20,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        cache-version: 1
     - name: Install dependencies
       run: bundle install
     - name: Run tests


### PR DESCRIPTION
Invalidate cached installed gems and `Gemfile.lock` (created with some previous `bundler` version).

See https://github.com/ruby/setup-ruby#dealing-with-a-corrupted-cache for details.